### PR TITLE
Pause two replicas at identical coordinates

### DIFF
--- a/lib/jetpants/db/replication.rb
+++ b/lib/jetpants/db/replication.rb
@@ -76,8 +76,9 @@ module Jetpants
       
       # sibling ahead of self: catch up to sibling
       sibling_coords = sibling.repl_binlog_coordinates
+      output "Resuming replication from #{@master} until (#{sibling_coords[0]}, #{sibling_coords[1]})."
       output(mysql_root_cmd "START SLAVE UNTIL MASTER_LOG_FILE = '#{sibling_coords[0]}', MASTER_LOG_POS = #{sibling_coords[1]}")
-      sleep 1 while repl_binlog_coordinates != sibling.repl_binlog_coordinates
+      sleep 1 while repl_binlog_coordinates != sibling_coords
       true
     end
     


### PR DESCRIPTION
This branch adds two new methods to Jetpants::DB:
- pause_replication_with(sibling) stops replication on self and sibling at the exact same coordinates. This can be useful in situations in which query results must be compared between slaves. For example, when using Percona's pt-upgrade tool to ensure that query results are unchanged in a newer version of MySQL.
- ahead_of?(node) returns true if self's replication progress is ahead of another node in the same pool. It's primarily a helper method used by pause_replication_with.
